### PR TITLE
Switch OAuth login to redirect flow

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,5 @@
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,8 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{userId}/companyProfile/{document=**} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+  }
+}

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -3,8 +3,8 @@ import React, { createContext, useContext, useEffect, useState } from "react";
 import {
   createUserWithEmailAndPassword,
   signInWithEmailAndPassword,
-  signInWithPopup,
   signInWithRedirect,
+  getRedirectResult,
   signOut,
   onAuthStateChanged,
 } from "firebase/auth";
@@ -28,6 +28,19 @@ export function AuthProvider({ children }) {
       setLoading(false);
     });
     return unsubscribe;
+  }, []);
+
+  // 1b) Handle redirect sign-in results
+  useEffect(() => {
+    getRedirectResult(auth)
+      .then((result) => {
+        if (result && result.user) {
+          setCurrentUser(result.user);
+        }
+      })
+      .catch((err) => {
+        console.error("Redirect sign-in error", err);
+      });
   }, []);
 
   // 2) Email/Password Registration

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -37,21 +37,7 @@ export default function ProfilePage() {
   const [website, setWebsite] = useState("");
   const [vatNumber, setVatNumber] = useState("");
 
-  // 1) Listen for Auth state; once we have a user, fetch profile
-  useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
-      if (currentUser) {
-        setUser(currentUser);
-        fetchProfile(currentUser.uid);
-      } else {
-        setUser(null);
-        setLoadingProfile(false);
-      }
-    });
-    return () => unsubscribe();
-  }, [auth, fetchProfile]);
-
-  // 2) Fetch existing profile from Firestore
+  // 1) Fetch existing profile from Firestore
   const fetchProfile = React.useCallback(
     async (uid) => {
       setLoadingProfile(true);
@@ -78,6 +64,20 @@ export default function ProfilePage() {
     },
     [db]
   );
+
+  // 2) Listen for Auth state; once we have a user, fetch profile
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+      if (currentUser) {
+        setUser(currentUser);
+        fetchProfile(currentUser.uid);
+      } else {
+        setUser(null);
+        setLoadingProfile(false);
+      }
+    });
+    return () => unsubscribe();
+  }, [auth, fetchProfile]);
 
   // 3) Handle logo file selection
   const handleLogoChange = (e) => {


### PR DESCRIPTION
## Summary
- remove popup sign-in import and use redirect flow
- handle OAuth redirect result in `AuthContext`
- add basic Firestore security rules

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841bb55c138832b9bc57f1a90f6c410