### PR TITLE
Switch OAuth login to redirect flow

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,5 @@
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,8 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{userId}/companyProfile/{document=**} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+  }
+}

--- a/src/assets/styles/pages/_profilePage.scss
+++ b/src/assets/styles/pages/_profilePage.scss
@@ -13,6 +13,12 @@
     color: #4d90fe; // use the same primary blue
   }
 
+  .logged-in-email {
+    margin-bottom: 1rem;
+    font-size: 0.875rem;
+    color: #555;
+  }
+
   .profile-form {
     display: flex;
     flex-direction: column;

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -3,8 +3,8 @@ import React, { createContext, useContext, useEffect, useState } from "react";
 import {
   createUserWithEmailAndPassword,
   signInWithEmailAndPassword,
-  signInWithPopup,
   signInWithRedirect,
+  getRedirectResult,
   signOut,
   onAuthStateChanged,
 } from "firebase/auth";
@@ -28,6 +28,19 @@ export function AuthProvider({ children }) {
       setLoading(false);
     });
     return unsubscribe;
+  }, []);
+
+  // 1b) Handle redirect sign-in results
+  useEffect(() => {
+    getRedirectResult(auth)
+      .then((result) => {
+        if (result && result.user) {
+          setCurrentUser(result.user);
+        }
+      })
+      .catch((err) => {
+        console.error("Redirect sign-in error", err);
+      });
   }, []);
 
   // 2) Email/Password Registration

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -37,21 +37,7 @@ export default function ProfilePage() {
   const [website, setWebsite] = useState("");
   const [vatNumber, setVatNumber] = useState("");
 
-  // 1) Listen for Auth state; once we have a user, fetch profile
-  useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
-      if (currentUser) {
-        setUser(currentUser);
-        fetchProfile(currentUser.uid);
-      } else {
-        setUser(null);
-        setLoadingProfile(false);
-      }
-    });
-    return () => unsubscribe();
-  }, [auth, fetchProfile]);
-
-  // 2) Fetch existing profile from Firestore
+  // 1) Fetch existing profile from Firestore
   const fetchProfile = React.useCallback(
     async (uid) => {
       setLoadingProfile(true);
@@ -78,6 +64,20 @@ export default function ProfilePage() {
     },
     [db]
   );
+
+  // 2) Listen for Auth state; once we have a user, fetch profile
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+      if (currentUser) {
+        setUser(currentUser);
+        fetchProfile(currentUser.uid);
+      } else {
+        setUser(null);
+        setLoadingProfile(false);
+      }
+    });
+    return () => unsubscribe();
+  }, [auth, fetchProfile]);
 
   // 3) Handle logo file selection
   const handleLogoChange = (e) => {
@@ -179,6 +179,9 @@ export default function ProfilePage() {
   return (
     <div className="profile-page">
       <h2>Company Profile</h2>
+      {user && (
+        <p className="logged-in-email">Logged in as {user.email}</p>
+      )}
       <form className="profile-form" onSubmit={handleSaveProfile}>
         {/* Company Name */}
         <div className="form-group">

--- a/src/pages/SignInPage.jsx
+++ b/src/pages/SignInPage.jsx
@@ -1,6 +1,7 @@
 // src/pages/SignInPage.jsx
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useAuth } from "../contexts/AuthContext";
+import { useNavigate } from "react-router-dom";
 import "../assets/styles/pages/_signInPage.scss";
 
 export default function SignInPage() {
@@ -10,11 +11,20 @@ export default function SignInPage() {
     loginWithGoogle,
     loginWithApple,
   } = useAuth();
+  const { currentUser } = useAuth();
+  const navigate = useNavigate();
 
   const [isRegister, setIsRegister] = useState(false);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
+
+  // Navigate to the profile page once a user is authenticated
+  useEffect(() => {
+    if (currentUser) {
+      navigate("/profile");
+    }
+  }, [currentUser, navigate]);
 
   const handleEmailSubmit = async (e) => {
     e.preventDefault();
@@ -25,6 +35,8 @@ export default function SignInPage() {
       } else {
         await loginWithEmail(email, password);
       }
+      // After successful email auth, go to profile
+      navigate("/profile");
     } catch (err) {
       console.error("Email auth error", err);
       setError(err.message);


### PR DESCRIPTION
## Summary
- remove popup sign-in import and use redirect flow
- handle OAuth redirect result in `AuthContext`
- redirect to profile page when user logs in
- show logged-in user's email on Profile page

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841bb55c138832b9bc57f1a90f6c410