### PR TITLE
feat: Add item image to offer PDF

### DIFF
--- a/src/components/OfferPdf.jsx
+++ b/src/components/OfferPdf.jsx
@@ -101,12 +101,22 @@ const styles = StyleSheet.create({
     fontSize: 9,
   },
   tableCellDescription: {
-    width: "35%",
+    width: "30%", // Adjusted width
     paddingLeft: 4,
     fontSize: 9,
   },
+  tableCellImage: { // New style for image cell
+    width: "10%",
+    padding: 2,
+    textAlign: "center",
+  },
+  itemImage: { // New style for the image itself
+    maxWidth: "100%",
+    maxHeight: 40, // Adjust as needed
+    objectFit: "contain",
+  },
   tableCellDimensions: {
-    width: "15%",
+    width: "10%", // Adjusted width
     textAlign: "center",
     fontSize: 9,
   },
@@ -297,6 +307,7 @@ const OfferPdf = ({ data }) => {
           <View style={styles.tableHeader}>
             <Text style={styles.tableCellPos}>Pos.</Text>
             <Text style={styles.tableCellDescription}>Bezeichnung</Text>
+            <Text style={styles.tableCellImage}>Bild</Text> {/* New Header */}
             <Text style={styles.tableCellDimensions}>Breite × Höhe (mm)</Text>
             <Text style={styles.tableCellColor}>Farbe</Text>
             <Text style={styles.tableCellQty}>Menge</Text>
@@ -311,6 +322,13 @@ const OfferPdf = ({ data }) => {
               <View style={styles.tableRow} key={idx}>
                 <Text style={styles.tableCellPos}>{item.pos}</Text>
                 <Text style={styles.tableCellDescription}>{item.description}</Text>
+                <View style={styles.tableCellImage}>
+                  {item.interiorImage ? (
+                    <Image style={styles.itemImage} src={item.interiorImage} />
+                  ) : (
+                    <Text>-</Text>
+                  )}
+                </View>
                 <Text style={styles.tableCellDimensions}>
                   {item.width}×{item.height}
                 </Text>


### PR DESCRIPTION
Modified OfferPdf.jsx to include images uploaded for offer items in the generated PDF.

- Added a new "Bild" (Image) column to the items table.
- The `item.interiorImage` (if present) is rendered in this column.
- Adjusted table column widths and styles to accommodate the new image.

Note: Further testing is required to confirm consistent rendering of SVG images. Raster images (PNG, JPEG) are expected to work.