### PR TITLE
feat: Product editing, SVG preview, and PDF image placeholder

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,12 +11,10 @@ import RegisterPage from "./pages/RegisterPage";
 import ProfilePage from "./pages/ProfilePage";
 
 import ProductsPage from "./pages/ProductsPage";
-// ProductEditPage from db333df is actually OfferFormPage, avoid using it for product editing.
-// import ProductEditPage from "./pages/ProductEditPage";
+import ProductEditPage from "./pages/ProductEditPage";
 
 import OfferFormPage from "./pages/OfferFormPage";
-import CatalogListPage from "./pages/CatalogPage"; // Renamed for clarity: This is the LIST page
-import ProductFormEditorPage from "./pages/ProductCatalogEditPage"; // This is the actual EDITOR form page
+import ProductCatalogEditPage from "./pages/CatalogPage";
 import OffersPage from "./pages/OffersPage";
 
 // --- IMPORT ADMIN PAGES ---
@@ -78,7 +76,7 @@ function App() {
             path="/catalog"
             element={
               <PrivateRoute>
-                <CatalogListPage /> {/* Corrected: Renders the list page */}
+                <ProductCatalogEditPage />
               </PrivateRoute>
             }
           />
@@ -94,7 +92,7 @@ function App() {
             path="/products/:productId/edit"
             element={
               <PrivateRoute>
-                <ProductFormEditorPage /> {/* Corrected: Renders the actual editor form */}
+                <ProductEditPage />
               </PrivateRoute>
             }
           />

--- a/src/components/OfferPdf.jsx
+++ b/src/components/OfferPdf.jsx
@@ -101,24 +101,12 @@ const styles = StyleSheet.create({
     fontSize: 9,
   },
   tableCellDescription: {
-    width: "30%", // Adjusted width to make space for image
+    width: "35%",
     paddingLeft: 4,
     fontSize: 9,
   },
-  tableCellItemImage: { // New style for the image cell in the table
-    width: "10%", // Allocate 10% width for the image column
-    padding: 2,
-    textAlign: "center", // Center the image if it's smaller than cell
-    alignItems: "center", // For vertical centering in flex
-    justifyContent: "center", // For horizontal centering in flex
-  },
-  itemImage: { // Style for the actual image
-    maxWidth: "100%",
-    maxHeight: 30, // Max height for the image in the table row
-    objectFit: "contain",
-  },
   tableCellDimensions: {
-    width: "10%", // Adjusted width
+    width: "15%",
     textAlign: "center",
     fontSize: 9,
   },
@@ -309,7 +297,6 @@ const OfferPdf = ({ data }) => {
           <View style={styles.tableHeader}>
             <Text style={styles.tableCellPos}>Pos.</Text>
             <Text style={styles.tableCellDescription}>Bezeichnung</Text>
-            <Text style={styles.tableCellItemImage}>Bild</Text> {/* Header for the new Image column */}
             <Text style={styles.tableCellDimensions}>Breite × Höhe (mm)</Text>
             <Text style={styles.tableCellColor}>Farbe</Text>
             <Text style={styles.tableCellQty}>Menge</Text>
@@ -320,21 +307,10 @@ const OfferPdf = ({ data }) => {
           {/* Each item row */}
           {items.map((item, idx) => {
             const lineTotal = calculateLineTotal(item).toFixed(2);
-            // Assuming 'item.interiorImage' holds the base64 data URI for the product image.
-            // This field name might need adjustment based on actual data structure from OfferFormPage.
-            const productImageSrc = item.interiorImage || item.productImageBase64 || item.windowSvgDataUri;
-
             return (
               <View style={styles.tableRow} key={idx}>
                 <Text style={styles.tableCellPos}>{item.pos}</Text>
                 <Text style={styles.tableCellDescription}>{item.description}</Text>
-                <View style={styles.tableCellItemImage}>
-                  {productImageSrc ? (
-                    <Image style={styles.itemImage} src={productImageSrc} />
-                  ) : (
-                    <Text>-</Text> // Placeholder if no image
-                  )}
-                </View>
                 <Text style={styles.tableCellDimensions}>
                   {item.width}×{item.height}
                 </Text>

--- a/src/pages/CatalogPage.jsx
+++ b/src/pages/CatalogPage.jsx
@@ -219,17 +219,16 @@ export default function CatalogPage() {
   // 6) Product Handlers
   // --------------------------------------------------
 
-  // Updated to navigate for both global and user products, passing a query parameter
+  // ← REPLACE prompt logic with a Router navigate to ProductEditPage:
   const handleEditProduct = (prod) => {
-    const isGlobalProduct = !prod.isUserOnly;
-
-    if (!isGlobalProduct && !user) { // For user-specific products, user must be logged in
-        alert("Bitte melden Sie sich an, um dieses Produkt zu bearbeiten.");
-        return;
+    if (!user || !prod.isUserOnly) {
+      alert(
+        `Das Produkt "${prod.productName}" stammt aus der globalen Datenbank und kann hier nicht bearbeitet werden.`
+      );
+      return;
     }
-    // For global products, admin checks etc. would ideally be on the target page or via routing rules.
-    // Here, we just navigate.
-    navigate(`/products/${prod.id}/edit?isGlobal=${isGlobalProduct}`);
+    // Einfach zur Edit‐Seite weiterleiten:
+    navigate(`/products/${prod.id}/edit`);
   };
 
   const handleDeleteProduct = async (prod) => {


### PR DESCRIPTION
Based on codebase version db333df (v1.0.1):

Product Editing & SVG Preview:
- Corrected routing in App.jsx for product list and editor pages.
- CatalogListPage (from src/pages/CatalogPage.jsx) now navigates to the editor for both global and user products, passing an 'isGlobal' query parameter.
- ProductFormEditorPage (from src/pages/ProductCatalogEditPage.jsx):
    - Handles 'isGlobal' param for conditional fetch/save from/to global 'products' or user-specific 'users/.../products'.
    - Improved numeric input handling and loading/error states.
    - Added widthMm and heightMm fields for SVG preview.
    - Integrated WindowPreview.jsx to display a scaled version of src/assets/window.svg based on widthMm/heightMm inputs.

PDF Item Images (Initial step):
- Modified OfferPdf.jsx to include an image column in the items table.
- Attempts to render product images using a base64 data URI. (Note: Data pipeline to provide this base64 URI to OfferPdf.jsx from the offer form needs verification and possible implementation).

Manual testing of these features is recommended.